### PR TITLE
Allow specifying a different character for the preview scrollbar

### DIFF
--- a/src/components/OptionsPanel.svelte
+++ b/src/components/OptionsPanel.svelte
@@ -127,7 +127,7 @@
     <FormControl label="Scrollbar">
       <input
         type="text"
-        maxlength="1"
+        maxlength="2"
         value={$optionsStore.scrollbar}
         on:input={(e) => void optionsStore.set('scrollbar', e.currentTarget.value)}
       />

--- a/src/data/options.schema.ts
+++ b/src/data/options.schema.ts
@@ -21,7 +21,7 @@ export const themeOptionsSchema = z.object({
   pointer: z.string().max(2).default('> '),
   marker: z.string().max(2).default('>'),
   separator: z.string().default('─'),
-  scrollbar: z.string().max(1).default('│'),
+  scrollbar: z.string().max(2).default('│'),
   layout: z.enum(['default', 'reverse', 'reverse-list']).default('default'),
   info: z.enum(['default', 'right']).default('default'),
 });

--- a/src/utils/tui/createFinderLines.ts
+++ b/src/utils/tui/createFinderLines.ts
@@ -6,7 +6,7 @@ const addScrollbarToLines = (count: number, lines: Line[], themeOptions: ThemeOp
   lines.forEach((line, i) => {
     if (i >= count) return;
 
-    line.tokens.push(fillSpace(' '), token(themeOptions.scrollbar, 'bg scrollbar'));
+    line.tokens.push(fillSpace(' '), token(themeOptions.scrollbar.substr(0, 1), 'bg scrollbar'));
   });
 
   return lines;

--- a/src/utils/tui/createPreviewLines.ts
+++ b/src/utils/tui/createPreviewLines.ts
@@ -5,18 +5,19 @@ import { addBorders } from '~/utils/tui/addBorders';
 import { addSpacing } from '~/utils/tui/addSpacing';
 
 export const createPreviewLines = (themeOptions: ThemeOptions) => {
+  let scrollbar = themeOptions.scrollbar.repeat(2).substr(1, 1);
   let previewLines = [
     new Line({
       className: 'preview-bg',
       tokens: [
         token('package fzf', 'preview-fg'),
         fillSpace(' ', 'preview-bg'),
-        token(themeOptions.scrollbar, 'preview-scrollbar'),
+        token(scrollbar, 'preview-scrollbar'),
       ],
     }),
     new Line({
       className: 'preview-bg',
-      tokens: [fillSpace(' ', 'preview-bg'), token(themeOptions.scrollbar, 'preview-scrollbar')],
+      tokens: [fillSpace(' ', 'preview-bg'), token(scrollbar, 'preview-scrollbar')],
     }),
     new Line({ className: 'preview-bg', tokens: [token('import (', 'preview-fg')] }),
     new Line({ className: 'preview-bg', tokens: [token('  "errors"', 'preview-fg')] }),


### PR DESCRIPTION
`--scrollbar` option can optionally take another character that is used to render the scrollbar of the preview window.